### PR TITLE
Don't access class fields

### DIFF
--- a/ArrayForVsForeach/Benchmark.cs
+++ b/ArrayForVsForeach/Benchmark.cs
@@ -29,12 +29,28 @@
         }
 
         [Benchmark]
-        public int ForLoopCount()
+        public int ForLoopCountFieldAccess()
         {
             int count = 0;
             for (int i = 0; i < _strings.Length; i++)
             {
                 if (_strings[i].Length == 0)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        [Benchmark]
+        public int ForLoopCountLocalAccess()
+        {
+            int count = 0;
+            var local = _strings;
+            for (int i = 0; i < local.Length; i++)
+            {
+                if (local[i].Length == 0)
                 {
                     count++;
                 }

--- a/ArrayForVsForeach/README.md
+++ b/ArrayForVsForeach/README.md
@@ -3,26 +3,29 @@
 
 ``` ini
 
-BenchmarkDotNet=v0.13.3, OS=Windows 11 (10.0.22631.3007), VM=Hyper-V
-AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores
-.NET SDK=8.0.101
-  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
-  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+BenchmarkDotNet v0.13.12, Windows 11 (10.0.22621.3737/22H2/2022Update/SunValley2)
+AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
+.NET SDK 8.0.300
+  [Host]     : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
 
 
 ```
-|           Method |  Count |          Mean |         Error |        StdDev | Code Size |
-|----------------- |------- |--------------:|--------------:|--------------:|----------:|
-|     **ForLoopCount** |     **10** |      **7.665 ns** |     **0.0225 ns** |     **0.0188 ns** |      **78 B** |
-| ForEachLoopCount |     10 |      4.388 ns |     0.0279 ns |     0.0248 ns |      59 B |
-|     **ForLoopCount** |    **100** |     **80.556 ns** |     **0.8420 ns** |     **0.7876 ns** |      **78 B** |
-| ForEachLoopCount |    100 |     46.016 ns |     0.6950 ns |     0.6501 ns |      59 B |
-|     **ForLoopCount** | **100000** | **75,068.564 ns** |   **934.6431 ns** |   **874.2658 ns** |      **78 B** |
-| ForEachLoopCount | 100000 | 56,700.293 ns | 2,338.8038 ns | 6,896.0158 ns |      59 B |
+| Method                  | Count  | Mean          | Error       | StdDev      | Code Size |
+|------------------------ |------- |--------------:|------------:|------------:|----------:|
+| ForLoopCountFieldAccess | 10     |      5.478 ns |   0.0332 ns |   0.0310 ns |      78 B |
+| ForLoopCountLocalAccess | 10     |      2.999 ns |   0.0168 ns |   0.0157 ns |      59 B |
+| ForEachLoopCount        | 10     |      3.004 ns |   0.0135 ns |   0.0112 ns |      59 B |
+| ForLoopCountFieldAccess | 100    |     54.543 ns |   0.4449 ns |   0.4162 ns |      78 B |
+| ForLoopCountLocalAccess | 100    |     32.095 ns |   0.6275 ns |   1.0133 ns |      59 B |
+| ForEachLoopCount        | 100    |     31.939 ns |   0.6707 ns |   0.9403 ns |      59 B |
+| ForLoopCountFieldAccess | 100000 | 51,594.918 ns | 386.5606 ns | 361.5890 ns |      78 B |
+| ForLoopCountLocalAccess | 100000 | 33,187.575 ns | 340.7506 ns | 318.7383 ns |      59 B |
+| ForEachLoopCount        | 100000 | 32,964.418 ns | 272.0465 ns | 254.4724 ns |      59 B |
 
-## .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
 ```assembly
-; Test.Benchmark.ForLoopCount()
+; Test.Benchmark.ForLoopCountFieldAccess()
        sub       rsp,28
        xor       eax,eax
        xor       edx,edx
@@ -55,7 +58,35 @@ M00_L04:
 ; Total bytes of code 78
 ```
 
-## .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
+```assembly
+; Test.Benchmark.ForLoopCountLocalAccess()
+       xor       eax,eax
+       mov       rcx,[rcx+8]
+       xor       edx,edx
+       mov       r8d,[rcx+8]
+       test      r8d,r8d
+       jle       short M00_L02
+       nop       dword ptr [rax]
+       nop       dword ptr [rax+rax]
+M00_L00:
+       mov       r10d,edx
+       mov       r10,[rcx+r10*8+10]
+       cmp       dword ptr [r10+8],0
+       je        short M00_L03
+M00_L01:
+       inc       edx
+       cmp       r8d,edx
+       jg        short M00_L00
+M00_L02:
+       ret
+M00_L03:
+       inc       eax
+       jmp       short M00_L01
+; Total bytes of code 59
+```
+
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
 ```assembly
 ; Test.Benchmark.ForEachLoopCount()
        xor       eax,eax
@@ -83,9 +114,9 @@ M00_L03:
 ; Total bytes of code 59
 ```
 
-## .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
 ```assembly
-; Test.Benchmark.ForLoopCount()
+; Test.Benchmark.ForLoopCountFieldAccess()
        sub       rsp,28
        xor       eax,eax
        xor       edx,edx
@@ -118,7 +149,35 @@ M00_L04:
 ; Total bytes of code 78
 ```
 
-## .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
+```assembly
+; Test.Benchmark.ForLoopCountLocalAccess()
+       xor       eax,eax
+       mov       rcx,[rcx+8]
+       xor       edx,edx
+       mov       r8d,[rcx+8]
+       test      r8d,r8d
+       jle       short M00_L02
+       nop       dword ptr [rax]
+       nop       dword ptr [rax+rax]
+M00_L00:
+       mov       r10d,edx
+       mov       r10,[rcx+r10*8+10]
+       cmp       dword ptr [r10+8],0
+       je        short M00_L03
+M00_L01:
+       inc       edx
+       cmp       r8d,edx
+       jg        short M00_L00
+M00_L02:
+       ret
+M00_L03:
+       inc       eax
+       jmp       short M00_L01
+; Total bytes of code 59
+```
+
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
 ```assembly
 ; Test.Benchmark.ForEachLoopCount()
        xor       eax,eax
@@ -146,9 +205,9 @@ M00_L03:
 ; Total bytes of code 59
 ```
 
-## .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
 ```assembly
-; Test.Benchmark.ForLoopCount()
+; Test.Benchmark.ForLoopCountFieldAccess()
        sub       rsp,28
        xor       eax,eax
        xor       edx,edx
@@ -181,7 +240,35 @@ M00_L04:
 ; Total bytes of code 78
 ```
 
-## .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
+```assembly
+; Test.Benchmark.ForLoopCountLocalAccess()
+       xor       eax,eax
+       mov       rcx,[rcx+8]
+       xor       edx,edx
+       mov       r8d,[rcx+8]
+       test      r8d,r8d
+       jle       short M00_L02
+       nop       dword ptr [rax]
+       nop       dword ptr [rax+rax]
+M00_L00:
+       mov       r10d,edx
+       mov       r10,[rcx+r10*8+10]
+       cmp       dword ptr [r10+8],0
+       je        short M00_L03
+M00_L01:
+       inc       edx
+       cmp       r8d,edx
+       jg        short M00_L00
+M00_L02:
+       ret
+M00_L03:
+       inc       eax
+       jmp       short M00_L01
+; Total bytes of code 59
+```
+
+## .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
 ```assembly
 ; Test.Benchmark.ForEachLoopCount()
        xor       eax,eax

--- a/ListForVsForeach/Benchmark.cs
+++ b/ListForVsForeach/Benchmark.cs
@@ -32,9 +32,10 @@
         public int ForLoopCount()
         {
             int count = 0;
-            for (int i = 0; i < _strings.Count; i++)
+            var temp = _strings;
+            for (int i = 0; i < temp.Count; i++)
             {
-                if (_strings[i].Length == 0)
+                if (temp[i].Length == 0)
                 {
                     count++;
                 }

--- a/ListForVsForeach/README.md
+++ b/ListForVsForeach/README.md
@@ -3,30 +3,30 @@
 
 ``` ini
 
-BenchmarkDotNet=v0.13.3, OS=Windows 11 (10.0.22631.3007), VM=Hyper-V
-AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores
-.NET SDK=8.0.101
-  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
-  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
+BenchmarkDotNet v0.13.12, Windows 11 (10.0.22621.3737/22H2/2022Update/SunValley2)
+AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
+.NET SDK 8.0.300
+  [Host]     : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.5 (8.0.524.21615), X64 RyuJIT AVX2
 
 
 ```
-|                                   Method |   Count |             Mean |          Error |         StdDev | Ratio | RatioSD |
-|----------------------------------------- |-------- |-----------------:|---------------:|---------------:|------:|--------:|
-|                             **ForLoopCount** |      **10** |         **7.859 ns** |      **0.0449 ns** |      **0.0420 ns** |  **0.85** |    **0.01** |
-|                         ForEachLoopCount |      10 |         9.271 ns |      0.0438 ns |      0.0410 ns |  1.00 |    0.00 |
-| ForEachLoopCountCollectionsMarshalAsSpan |      10 |         5.253 ns |      0.0110 ns |      0.0092 ns |  0.57 |    0.00 |
-|                  ListDotForEachLoopCount |      10 |        21.739 ns |      0.1659 ns |      0.1552 ns |  2.34 |    0.02 |
-|              ListExplicitEnumeratorCount |      10 |         9.033 ns |      0.0223 ns |      0.0198 ns |  0.97 |    0.01 |
-|                                          |         |                  |                |                |       |         |
-|                             **ForLoopCount** |    **1000** |       **795.897 ns** |      **6.0490 ns** |      **5.3623 ns** |  **0.73** |    **0.00** |
-|                         ForEachLoopCount |    1000 |     1,096.252 ns |      5.9054 ns |      5.5239 ns |  1.00 |    0.00 |
-| ForEachLoopCountCollectionsMarshalAsSpan |    1000 |       442.799 ns |      6.1065 ns |      5.7121 ns |  0.40 |    0.01 |
-|                  ListDotForEachLoopCount |    1000 |     1,060.895 ns |      1.9639 ns |      1.6399 ns |  0.97 |    0.01 |
-|              ListExplicitEnumeratorCount |    1000 |       807.018 ns |      3.8047 ns |      3.5590 ns |  0.74 |    0.00 |
-|                                          |         |                  |                |                |       |         |
-|                             **ForLoopCount** | **1000000** | **1,627,522.712 ns** | **13,741.8391 ns** | **12,181.7824 ns** |  **0.97** |    **0.01** |
-|                         ForEachLoopCount | 1000000 | 1,685,917.090 ns | 15,404.8032 ns | 13,655.9568 ns |  1.00 |    0.00 |
-| ForEachLoopCountCollectionsMarshalAsSpan | 1000000 | 1,405,823.275 ns | 11,514.3582 ns | 10,770.5378 ns |  0.83 |    0.01 |
-|                  ListDotForEachLoopCount | 1000000 | 1,887,875.521 ns | 17,728.2795 ns | 16,583.0436 ns |  1.12 |    0.01 |
-|              ListExplicitEnumeratorCount | 1000000 | 1,682,890.513 ns | 10,511.0114 ns |  9,317.7379 ns |  1.00 |    0.01 |
+| Method                                   | Count   | Mean             | Error          | StdDev         | Median           | Ratio | RatioSD |
+|----------------------------------------- |-------- |-----------------:|---------------:|---------------:|-----------------:|------:|--------:|
+| ForLoopCount                             | 10      |         5.417 ns |      0.1258 ns |      0.1398 ns |         5.344 ns |  0.85 |    0.02 |
+| ForEachLoopCount                         | 10      |         6.366 ns |      0.0751 ns |      0.0702 ns |         6.360 ns |  1.00 |    0.00 |
+| ForEachLoopCountCollectionsMarshalAsSpan | 10      |         3.664 ns |      0.0382 ns |      0.0357 ns |         3.662 ns |  0.58 |    0.01 |
+| ListDotForEachLoopCount                  | 10      |        16.288 ns |      0.3502 ns |      1.0326 ns |        15.877 ns |  2.79 |    0.11 |
+| ListExplicitEnumeratorCount              | 10      |         6.233 ns |      0.0715 ns |      0.0597 ns |         6.200 ns |  0.98 |    0.01 |
+|                                          |         |                  |                |                |                  |       |         |
+| ForLoopCount                             | 1000    |       551.896 ns |      7.7284 ns |      7.2292 ns |       553.143 ns |  0.97 |    0.02 |
+| ForEachLoopCount                         | 1000    |       567.754 ns |      9.0915 ns |      8.5042 ns |       564.903 ns |  1.00 |    0.00 |
+| ForEachLoopCountCollectionsMarshalAsSpan | 1000    |       312.821 ns |      6.2216 ns |      6.3892 ns |       313.339 ns |  0.55 |    0.01 |
+| ListDotForEachLoopCount                  | 1000    |       750.051 ns |      6.8144 ns |      6.3742 ns |       751.437 ns |  1.32 |    0.02 |
+| ListExplicitEnumeratorCount              | 1000    |       563.815 ns |      5.8169 ns |      5.4412 ns |       563.557 ns |  0.99 |    0.02 |
+|                                          |         |                  |                |                |                  |       |         |
+| ForLoopCount                             | 1000000 | 1,456,250.579 ns | 29,065.0520 ns | 27,187.4677 ns | 1,461,995.215 ns |  0.97 |    0.02 |
+| ForEachLoopCount                         | 1000000 | 1,498,270.195 ns | 21,420.8591 ns | 20,037.0849 ns | 1,501,322.266 ns |  1.00 |    0.00 |
+| ForEachLoopCountCollectionsMarshalAsSpan | 1000000 | 1,262,601.055 ns | 16,024.7643 ns | 14,989.5745 ns | 1,260,369.531 ns |  0.84 |    0.01 |
+| ListDotForEachLoopCount                  | 1000000 | 1,635,871.177 ns | 32,122.9391 ns | 46,069.7594 ns | 1,616,172.266 ns |  1.10 |    0.03 |
+| ListExplicitEnumeratorCount              | 1000000 | 1,486,582.380 ns | 13,707.3991 ns | 12,151.2523 ns | 1,482,133.496 ns |  0.99 |    0.01 |


### PR DESCRIPTION
Accessing a field every time instead of a local could have side effects by forcing the JIT to assume the field could have changed reference. A local should be more consistent. Doesn't really impact the results, but it's technically more correct.
