### PR TITLE
Add Span2D comparison for MultiDimensionalVsJaggedArray

### DIFF
--- a/MultiDimensionalVsJaggedArray/Benchmark.cs
+++ b/MultiDimensionalVsJaggedArray/Benchmark.cs
@@ -1,4 +1,6 @@
-﻿namespace Test
+﻿using CommunityToolkit.HighPerformance;
+
+namespace Test
 {
     using BenchmarkDotNet.Attributes;
     using BenchmarkDotNet.Jobs;
@@ -233,6 +235,37 @@
             long result = 0;
             result = _mdim.Cast<byte>().Sum(x => x);
 
+            return result;
+        }
+
+        [Benchmark]
+        public long SumSpan2DLocalVariableForEach()
+        {
+            var mdspan = _mdim.AsSpan2D();
+            long result = 0;
+
+            foreach (var v in mdspan)
+            {
+                result += v;
+            }
+
+            return result;
+        }
+
+        [Benchmark]
+        public long SumSpan2DLocalVariableIndex()
+        {
+            var mdspan = _mdim.AsSpan2D();
+            var size = Size;
+
+            long result = 0;
+            for (int i = 0; i < size; i++)
+            {
+                for (int j = 0; j < size; j++)
+                {
+                    result += mdspan[i, j];
+                }
+            }
             return result;
         }
     }

--- a/MultiDimensionalVsJaggedArray/Benchmark.csproj
+++ b/MultiDimensionalVsJaggedArray/Benchmark.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This adds `CommunityToolkit.HighPerformance.Span2D` comparison for `MultiDimensionalVsJaggedArray` benchmarks. ForEach version and accessing-by-index version.

`SumSpan2DLocalVariableForEach` almost ties with `SumJaggedLocalVariableGoose` on .NET 8, but `SumJaggedLocalVariableGoose` is faster on .NET 9. Possibly because CommunityToolkit.HighPerformance doesn't utilize .NET 9 features yet.