### PR TITLE
Add Span2D comparison for MultiDimensionalVsJaggedArray

### DIFF
--- a/MultiDimensionalVsJaggedArray/Benchmark.cs
+++ b/MultiDimensionalVsJaggedArray/Benchmark.cs
@@ -1,3 +1,5 @@
+using CommunityToolkit.HighPerformance;
+
 namespace Test;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
@@ -233,6 +235,37 @@ public class Benchmark
         long result = 0;
         result = _mdim.Cast<byte>().Sum(x => x);
 
+        return result;
+    }
+
+    [Benchmark]
+    public long SumSpan2DLocalVariableForEach()
+    {
+        var mdspan = _mdim.AsSpan2D();
+        long result = 0;
+
+        foreach (var v in mdspan)
+        {
+            result += v;
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    public long SumSpan2DLocalVariableIndex()
+    {
+        var mdspan = _mdim.AsSpan2D();
+        var size = Size;
+
+        long result = 0;
+        for (int i = 0; i < size; i++)
+        {
+            for (int j = 0; j < size; j++)
+            {
+                result += mdspan[i, j];
+            }
+        }
         return result;
     }
 }

--- a/MultiDimensionalVsJaggedArray/Benchmark.csproj
+++ b/MultiDimensionalVsJaggedArray/Benchmark.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Rebases the changes from #15 by @cathei onto current main, resolving merge conflicts caused by the file-scoped namespace refactoring.

Adds two \CommunityToolkit.HighPerformance.Span2D\ benchmark methods to \MultiDimensionalVsJaggedArray\:
- \SumSpan2DLocalVariableForEach\ — iterates Span2D with foreach
- \SumSpan2DLocalVariableIndex\ — iterates Span2D with nested index loops

Closes #15